### PR TITLE
TicketField model was missing a AlernateName (record)

### DIFF
--- a/ZenDeskApi/Model/TicketField.cs
+++ b/ZenDeskApi/Model/TicketField.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using ZenDeskApi.XmlSerializers;
 
 namespace ZenDeskApi.Model
 {
+    [ZenDeskSerialization(AlternateName = "record")]
     public class TicketField
     {
         public int AccountId { get; set; }


### PR DESCRIPTION
TicketField model was missing a AlernateName serialization attribute (for record)
